### PR TITLE
Add `NodeAdapter` trait and edge implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Install protoc
+        run: sudo apt-get install -y protobuf-compiler
+
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,14 @@
 members = ["parser", "node_adapter"]
 resolver = "2"
 
+
+[workspace.dependencies]
+serde_json = "1.0.106"
+log = "0.4.19"
+plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "0b5ac312c0f9efdcc6d85c10256d2843d42215a2" }
+rlp = "0.5.2"
+hex = "0.4.3"
+
 [patch.crates-io]
 # TODO: Remove `eth_trie_utils` patch once version `0.7.0` is released...
 eth_trie_utils = { git = "https://github.com/mir-protocol/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }

--- a/node_adapter/Cargo.toml
+++ b/node_adapter/Cargo.toml
@@ -1,8 +1,29 @@
 [package]
-name = "node_adapter"
+name = "plonky_node_adapter"
 version = "0.1.0"
 edition = "2021"
+authors = ["Polygon Zero <zbrown@polygon.technology>"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tonic = "0.10.1"
+prost = "0.12.1"
+tokio = { version = "1.32.0", features = ["time", "sync", "macros"] }
+tokio-stream = "0.1.14"
+pin-project = "1.1.3"
+futures = "0.3.28"
+anyhow = "1.0.75"
+backoff = { version = "0.4.0", features = ["tokio"] }
+plonky_edge_block_trace_parser = { path = "../parser" }
+serde_json = { workspace = true }
+log = { workspace = true }
+plonky2_evm = { workspace = true }
+rlp = { workspace = true }
+hex = { workspace = true }
+
+[build-dependencies]
+tonic-build = "0.10.1"
+
+[dev-dependencies]
+tokio = { version = "1.32.0", features = ["full"] }

--- a/node_adapter/build.rs
+++ b/node_adapter/build.rs
@@ -1,0 +1,4 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::compile_protos("src/edge/proto/system.proto")?;
+    Ok(())
+}

--- a/node_adapter/src/adapter.rs
+++ b/node_adapter/src/adapter.rs
@@ -1,4 +1,4 @@
-use futures::{future::BoxFuture, TryStream};
+use futures::TryStream;
 
 pub type BlockHeight = u64;
 
@@ -29,5 +29,5 @@ pub trait NodeAdapter {
     type St: TryStream<Item = Self::Trace, Error = Self::Error>;
 
     /// Create a new stream of traces.
-    fn get_stream(&self, config: StreamConfig) -> BoxFuture<'_, Result<Self::St, Self::Error>>;
+    fn get_stream(&self, config: StreamConfig) -> Self::St;
 }

--- a/node_adapter/src/adapter.rs
+++ b/node_adapter/src/adapter.rs
@@ -1,0 +1,33 @@
+use futures::{future::BoxFuture, TryStream};
+
+pub type BlockHeight = u64;
+
+/// Configuration for the stream.
+#[derive(Debug, Clone, Copy)]
+pub struct StreamConfig {
+    /// The starting block height.
+    pub start_height: BlockHeight,
+    /// The maximum number of traces to produce before blocking the sender.
+    ///
+    /// Once this limit is reached, the internal sending side of the channel
+    /// should wait to produce new traces until additional space opens up in the
+    /// buffer. This is to prevent unbounded memory consumption. Buffer space is
+    /// freed as messages are pulled from the receiving side of the channel.
+    ///
+    /// The appropriate value will depend on the consumer's ability and desire
+    /// to process traces concurrently.
+    pub buffer_size: usize,
+}
+
+/// An adapter for a node that can produce traces.
+pub trait NodeAdapter {
+    /// The type of trace produced by the node.
+    type Trace;
+    /// The type of error produced while producing traces.
+    type Error;
+    /// The type of stream produced by the node.
+    type St: TryStream<Item = Self::Trace, Error = Self::Error>;
+
+    /// Create a new stream of traces.
+    fn get_stream(&self, config: StreamConfig) -> BoxFuture<'_, Result<Self::St, Self::Error>>;
+}

--- a/node_adapter/src/edge/mod.rs
+++ b/node_adapter/src/edge/mod.rs
@@ -1,0 +1,325 @@
+use std::{pin::Pin, time::Duration};
+
+use anyhow::{anyhow, Context, Result};
+use backoff::{future::retry, ExponentialBackoffBuilder};
+use futures::{future::BoxFuture, Future, Stream};
+use pin_project::{pin_project, pinned_drop};
+use plonky2_evm::proof::BlockMetadata;
+use plonky_edge_block_trace_parser::edge_payloads::{EdgeBlockResponse, EdgeBlockTrace};
+use rlp::decode;
+use tokio::{sync::mpsc::channel, task::JoinHandle, try_join};
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::transport::Channel;
+
+use self::system::system_client::SystemClient;
+use crate::adapter::{BlockHeight, NodeAdapter, StreamConfig};
+
+pub mod system {
+    tonic::include_proto!("v1");
+}
+
+#[derive(Default)]
+pub struct EdgeConfig {
+    /// The URI of the gRPC node.
+    pub remote_uri: String,
+    /// How often the chain produces new blocks.
+    ///
+    /// This will be used to determine how long to wait before polling the node
+    /// for new block heights if the stream is caught up to the node.
+    pub block_time: Option<Duration>,
+}
+
+#[derive(Clone, Debug)]
+pub struct EdgeTraceWithMeta {
+    pub trace: EdgeBlockTrace,
+    pub b_meta: BlockMetadata,
+}
+
+/// The edge [`NodeAdapter`].
+///
+/// This adapter enables streaming [`EdgeTraceWithMeta`] instances starting from
+/// the given block height.
+///
+/// # Example
+/// ```no_run
+/// use plonky_node_adapter::{
+///     NodeAdapter, StreamConfig,
+///     edge::{EdgeConfig, EdgeNodeAdapter}
+/// };
+/// use futures::StreamExt;
+///
+/// # use anyhow::Result;
+/// #[tokio::main]
+/// async fn main() -> Result<()> {
+///     let edge = EdgeNodeAdapter::new(EdgeConfig {
+///         remote_uri: "http://[::1]:50051".to_string(),
+///         ..Default::default()
+///     });
+///
+///     let mut stream = edge
+///         .get_stream(StreamConfig {
+///             buffer_size: 1,
+///             start_height: 4242,
+///         })
+///         .await?;
+///
+///     while let Some(block) = stream.next().await {
+///         match block {
+///             Ok((height, block)) => {
+///                 println!("block {height}: {block:?}");
+///             }
+///             Err(e) => {
+///                 println!("error: {:?}", e);
+///             }
+///         }
+///     }
+/// # Ok(())
+/// }
+/// ```
+#[derive(Clone, Debug)]
+pub struct EdgeNodeAdapter {
+    /// How often the chain produces new blocks.
+    ///
+    /// This will be used to determine how long to wait before polling the node
+    /// for new block heights if the stream is caught up to the node.
+    block_time: Duration,
+    /// The URI of the remote node.
+    remote_uri: String,
+}
+
+/// A handle to a block stream that will abort the stream when dropped.
+///
+/// It implements [`Stream`], delegating to the given [`ReceiverStream`].
+#[pin_project(PinnedDrop)]
+pub struct StreamGuard<T> {
+    #[pin]
+    stream: ReceiverStream<T>,
+    handle: JoinHandle<()>,
+}
+
+impl<T> Stream for StreamGuard<T> {
+    type Item = T;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let this = self.project();
+        this.stream.poll_next(cx)
+    }
+}
+
+#[pinned_drop]
+impl<T> PinnedDrop for StreamGuard<T> {
+    fn drop(self: Pin<&mut Self>) {
+        self.handle.abort();
+    }
+}
+
+impl NodeAdapter for EdgeNodeAdapter {
+    type Trace = Result<(BlockHeight, EdgeTraceWithMeta), Self::Error>;
+    type Error = anyhow::Error;
+    type St = StreamGuard<Self::Trace>;
+
+    fn get_stream(
+        &self,
+        stream_config: StreamConfig,
+    ) -> BoxFuture<'_, Result<Self::St, Self::Error>> {
+        Box::pin(async move {
+            let client = self.get_client().await?;
+            let mut node_tip = Self::fetch_cur_node_height(client.clone()).await?;
+            let mut our_tip = stream_config.start_height;
+            let block_time = self.block_time;
+            let (tx, rx) = channel(stream_config.buffer_size);
+
+            let handle = tokio::spawn(async move {
+                loop {
+                    // Update our version of the node tip once we've caught up to it.
+                    // This is an optimization based on the assumption that processing blocks in the
+                    // consumer will generally be slower than the rate at which the node produces
+                    // them. In particular, rather than continuously polling the node for the
+                    // current block height, we _lazily_ do so only when we've caught up to the last
+                    // node tip we've seen.
+                    if our_tip >= node_tip {
+                        // Attempt to fetch the next node tip.
+                        let next_node_tip = Self::fetch_cur_node_height(client.clone()).await;
+
+                        match next_node_tip {
+                            Ok(next_node_tip) => {
+                                // Success, update our tip.
+                                node_tip = next_node_tip;
+                            }
+                            Err(err) => {
+                                // Notify the receiver that we've encountered an error.
+                                let send = tx.send(Err(err)).await;
+                                // If send errors, the receiver has been dropped.
+                                if send.is_err() {
+                                    break;
+                                }
+                            }
+                        }
+
+                        if our_tip >= node_tip {
+                            // If the node tip hasn't changed, sleep for the block time.
+                            tokio::time::sleep(block_time).await;
+                            continue;
+                        }
+                    }
+
+                    let trace_with_meta =
+                        Self::fetch_edge_trace_with_metadata_for_height(client.clone(), our_tip)
+                            .await;
+
+                    // This will block if the buffer is full, waiting until there is space.
+                    let send = tx.send(trace_with_meta.map(|t| (our_tip, t))).await;
+                    // If send errors, the receiver has been dropped.
+                    if send.is_err() {
+                        break;
+                    }
+
+                    // Increment our tip.
+                    our_tip += 1;
+                }
+            });
+
+            Ok(StreamGuard {
+                stream: ReceiverStream::new(rx),
+                handle,
+            })
+        })
+    }
+}
+
+const RETRY_MAX_ELAPSED_TIME: Duration = Duration::from_secs(60);
+/// Retry the given async operation with exponential backoff.
+async fn with_retry<F, Fut, R, E>(f: F) -> Result<R, E>
+where
+    Fut: Future<Output = Result<R, backoff::Error<E>>>,
+    F: FnMut() -> Fut,
+{
+    retry(
+        ExponentialBackoffBuilder::new()
+            .with_max_elapsed_time(Some(RETRY_MAX_ELAPSED_TIME))
+            .build(),
+        f,
+    )
+    .await
+}
+
+const EDGE_DEFAULT_BLOCK_TIME: Duration = Duration::from_secs(2);
+
+impl EdgeNodeAdapter {
+    pub fn new(
+        EdgeConfig {
+            remote_uri,
+            block_time,
+        }: EdgeConfig,
+    ) -> Self {
+        Self {
+            block_time: block_time.unwrap_or(EDGE_DEFAULT_BLOCK_TIME),
+            remote_uri,
+        }
+    }
+
+    async fn get_client(&self) -> Result<SystemClient<Channel>> {
+        SystemClient::connect(self.remote_uri.to_string())
+            .await
+            .context("Failed to connect to gRPC node")
+    }
+
+    /// Fetch the current block height from the node.
+    async fn fetch_cur_node_height(client: SystemClient<Channel>) -> Result<BlockHeight> {
+        with_retry(|| {
+            let mut client = client.clone();
+            async move {
+                Ok(client
+                    .get_status(())
+                    .await
+                    .map_err(anyhow::Error::from)
+                    .and_then(|r| {
+                        r.into_inner()
+                            .current
+                            .ok_or_else(|| anyhow!("ServerStatus contained empty Block"))
+                            .map(|c| c.number as BlockHeight)
+                    })
+                    .context("Failed to fetch node's current block height")?)
+            }
+        })
+        .await
+    }
+
+    /// Fetch the trace for the given block height.
+    ///
+    /// The edge node returns a byte array containing a JSON-encoded trace. This
+    /// function deserializes the JSON and returns an [`EdgeBlockTrace`].
+    async fn fetch_trace_for_height(
+        client: SystemClient<Channel>,
+        height: BlockHeight,
+    ) -> Result<EdgeBlockTrace> {
+        with_retry(|| {
+            let mut client = client.clone();
+            async move {
+                Ok(client
+                    .get_trace(system::GetTraceRequest { number: height })
+                    .await
+                    .map_err(anyhow::Error::from)
+                    .and_then(|r| {
+                        serde_json::from_slice(&r.into_inner().trace).map_err(anyhow::Error::from)
+                    })
+                    .with_context(|| format!("Failed to fetch trace for block {height}"))?)
+            }
+        })
+        .await
+    }
+
+    /// Fetch the block metadata for the given block height.
+    ///
+    /// The edge node returns an RLP-encoded block metadata payload. This
+    /// function decodes the payload and returns the decoded [`BlockMetadata`].
+    async fn fetch_metadata_for_height(
+        client: SystemClient<Channel>,
+        height: BlockHeight,
+    ) -> Result<BlockMetadata> {
+        with_retry(|| {
+            let mut client = client.clone();
+            async move {
+                Ok(client
+                    .block_by_number(system::BlockByNumberRequest { number: height })
+                    .await
+                    .map_err(anyhow::Error::from)
+                    .and_then(|resp| {
+                        let resp = resp.into_inner().data;
+                        decode::<EdgeBlockResponse>(&resp)
+                            .map(|resp| resp.into())
+                            .map_err(|err| {
+                                anyhow!(
+                                    "Parsing block metadata for block {} with err: {} \n({:?})",
+                                    height,
+                                    err,
+                                    hex::encode(&resp)
+                                )
+                            })
+                    })
+                    .context("Failed to fetch block by number")?)
+            }
+        })
+        .await
+    }
+
+    /// Fetch the trace and metadata for the given block height.
+    ///
+    /// This returns a fully decoded and deserialized [`EdgeTraceWithMeta`]
+    /// struct.
+    async fn fetch_edge_trace_with_metadata_for_height(
+        client: SystemClient<Channel>,
+        height: BlockHeight,
+    ) -> Result<EdgeTraceWithMeta> {
+        let (trace, b_meta) = try_join!(
+            Self::fetch_trace_for_height(client.clone(), height),
+            Self::fetch_metadata_for_height(client, height)
+        )
+        .context("Failed to join trace and block metadata")?;
+
+        Ok(EdgeTraceWithMeta { trace, b_meta })
+    }
+}

--- a/node_adapter/src/edge/proto/system.proto
+++ b/node_adapter/src/edge/proto/system.proto
@@ -1,0 +1,108 @@
+syntax = "proto3";
+
+package v1;
+
+option go_package = "/server/proto";
+
+import "google/protobuf/empty.proto";
+
+service System {
+  // GetInfo returns info about the client
+  rpc GetStatus(google.protobuf.Empty) returns (ServerStatus);
+
+  rpc GetTrace(GetTraceRequest) returns (GetTraceResponse);
+
+  // PeersAdd adds a new peer
+  rpc PeersAdd(PeersAddRequest) returns (PeersAddResponse);
+
+  // PeersList returns the list of peers
+  rpc PeersList(google.protobuf.Empty) returns (PeersListResponse);
+
+  // PeersInfo returns the info of a peer
+  rpc PeersStatus(PeersStatusRequest) returns (Peer);
+
+  // Subscribe subscribes to blockchain events
+  rpc Subscribe(google.protobuf.Empty) returns (stream BlockchainEvent);
+
+  // Export returns blockchain data
+  rpc BlockByNumber(BlockByNumberRequest) returns (BlockResponse);
+
+  // Export returns blockchain data
+  rpc Export(ExportRequest) returns (stream ExportEvent);
+}
+
+message GetTraceRequest {
+  uint64 number = 1;
+}
+
+message GetTraceResponse {
+  bytes trace = 1;
+}
+
+message BlockchainEvent {
+  repeated Header added = 1;
+  repeated Header removed = 2;
+
+  message Header {
+    int64 number = 1;
+    string hash = 2;
+  }
+}
+
+message ServerStatus {
+  int64 network = 1;
+
+  string genesis = 2;
+
+  Block current = 3;
+
+  string p2pAddr = 4;
+
+  message Block {
+    int64 number = 1;
+    string hash = 2;
+  }
+}
+
+message Peer {
+  string id = 1;
+  repeated string protocols = 2;
+  repeated string addrs = 3;
+}
+
+message PeersAddRequest {
+  string id = 1;
+}
+
+message PeersAddResponse {
+  string message = 1;
+}
+
+message PeersStatusRequest {
+  string id = 1;
+}
+
+message PeersListResponse {
+  repeated Peer peers = 1;
+}
+
+message BlockByNumberRequest {
+  uint64 number = 1;
+}
+
+message BlockResponse {
+  bytes data = 1;
+}
+
+message ExportRequest {
+  uint64 from = 1;
+  uint64 to = 2;
+}
+
+message ExportEvent {
+  uint64 from = 1;
+  // null when zero
+  uint64 to = 2;
+  uint64 latest = 3;
+  bytes data = 4;
+}

--- a/node_adapter/src/lib.rs
+++ b/node_adapter/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod adapter;
+pub mod edge;
+pub use adapter::{NodeAdapter, StreamConfig};

--- a/node_adapter/src/main.rs
+++ b/node_adapter/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -9,17 +9,17 @@ edition = "2021"
 [dependencies]
 ethereum-types = "0.14.1"
 eth_trie_utils = "0.6.0"
-hex = "0.4.3"
+hex = { workspace = true }
 keccak-hash = "0.10.0"
-log = "0.4.19"
+log = { workspace = true }
 plonky_block_proof_gen = { git = "https://github.com/mir-protocol/plonky-block-proof-gen.git", rev = "82cfa46971f7884de66cce22c3836065f4db447e" }
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "0b5ac312c0f9efdcc6d85c10256d2843d42215a2" }
-rlp = "0.5.2"
+plonky2_evm = { workspace = true }
+rlp = { workspace = true }
 rlp-derive = "0.1.0"
 rust_decimal = "1.32.0"
 serde = "1.0.166"
 serde_with = { version = "3.0.0", features = ["base64"] }
 
 # TODO: Replace!
-serde_json = "1.0.106"
+serde_json = { workspace = true }
 thiserror = "1.0.41"


### PR DESCRIPTION
This PR adds a `NodeAdapter` trait and an implementation for edge. 

# Usage example

```rust
use plonky_node_adapter::{
    NodeAdapter, StreamConfig,
    edge::{EdgeConfig, EdgeNodeAdapter}
};
use futures::StreamExt;
use anyhow::Result;

#[tokio::main]
async fn main() -> Result<()> {
  let edge = EdgeNodeAdapter::from_config(EdgeConfig {
      remote_uri: "http://[::1]:50051".to_string(),
      ..Default::default()
  })
  .await?;

  let mut stream = edge
      .get_stream(StreamConfig {
          buffer_size: 1,
          start_height: 4242,
      });

  while let Some(block) = stream.next().await {
      match block {
          Ok((height, block)) => {
              println!("block {height}: {block:?}");
          }
          Err(e) => {
              println!("error: {:?}", e);
          }
      }
  }
  
  Ok(())
}
```