### PR TITLE
Update `EdgeBlockResponse` to include hash. Return EdgeBlockResponse

### DIFF
--- a/parser/src/edge_payloads.rs
+++ b/parser/src/edge_payloads.rs
@@ -245,6 +245,7 @@ pub struct EdgeBlockResponseHeader {
     pub timestamp: u64,
     pub extra_data: Vec<u8>,
     pub mix_hash: H256,
+    pub hash: H256,
     pub nonce: Vec<u8>,
     pub base_fee: u64,
 }


### PR DESCRIPTION
Consumers of the `EdgeNodeAdapter` will need access to the block hash of each block so that they can properly construct [`BlockHashes`](https://github.com/0xPolygonZero/plonky2/blob/cd36e96cb844f3042aa7acf9c03ea8e66735c904/evm/src/proof.rs#L84). Right now the `EdgeNodeAdapter` provides the [`BlockMetadata`](https://github.com/0xPolygonZero/plonky2/blob/cd36e96cb844f3042aa7acf9c03ea8e66735c904/evm/src/proof.rs#L99) struct as part of its payload, which is problematic for this case, as `BlockMetadata` is a munged and stripped down version of `EdgeBlockResponse`, which doesn't provide access to the block hash.

 To address this, this PR does two things:

1. Adds `hash: H256` to the `EdgeBlockResponseHeader`. This field is [provided by edge](https://github.com/0xPolygon/polygon-edge/blob/develop/types/header.go#L73).
2. Updates `EdgeNodeAdapter` to yield `EdgeBlockResponse` so that consumers can access the block hash.

Given that there is an `impl From<EdgeBlockResponse> for BlockMetadata`, it should be trivial for consumers to acquire `BlockMetadata` once they have an `EdgeBlockResponse` (while the inverse is not true).