### PR TITLE
Txn and receipt tries

### DIFF
--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -12,7 +12,7 @@ eth_trie_utils = "0.6.0"
 hex = { workspace = true }
 keccak-hash = "0.10.0"
 log = { workspace = true }
-plonky_block_proof_gen = { git = "https://github.com/mir-protocol/plonky-block-proof-gen.git", rev = "0223001b5dc0ebfc77918bb502811eeea0487edc" }
+plonky_block_proof_gen = { git = "https://github.com/mir-protocol/plonky-block-proof-gen.git", rev = "44b24560e63367b7f161923e62e1da8bf998c5c8" }
 plonky2_evm = { workspace = true }
 rlp = { workspace = true }
 rlp-derive = "0.1.0"

--- a/parser/src/edge_payloads.rs
+++ b/parser/src/edge_payloads.rs
@@ -61,14 +61,11 @@ pub struct TxnBytesAndTraces {
     /// The root of the txn trie after the txn has been executed.
     pub txn_root: H256,
 
-    // ReceiptNodeHash is the hash of the new txn node added by the txn.
-    pub txn_node_bytes: Vec<u8>,
-
     /// The root of the receipt trie after the txn has been executed.
     pub receipt_root: H256,
 
     // ReceiptNodeHash is the hash of the new receipt node added by the txn.
-    pub receipt_node_bytes: Vec<u8>,
+    pub receipt: Vec<u8>,
 
     // GasUsed is the amount of gas used by the transaction
     pub gas_used: u64,

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(iter_array_chunks)]
+
 pub mod edge_payloads;
 pub mod plonky2;
 pub mod plonky3;

--- a/parser/src/plonky2.rs
+++ b/parser/src/plonky2.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
     fmt::{Display, Formatter},
+    iter::once,
     str::FromStr,
 };
 


### PR DESCRIPTION
Now creates the txn and receipt tries needed by each txn proof. Previously it was always getting empty tries and causing a panic in plonky2.